### PR TITLE
Replication DOES support client-side encryption.

### DIFF
--- a/doc_source/replication-config-for-kms-objects.md
+++ b/doc_source/replication-config-for-kms-objects.md
@@ -9,7 +9,7 @@ Welcome to the new **Amazon S3 User Guide**\! The Amazon S3 User Guide combines 
 By default, Amazon S3 doesn't replicate objects that are stored at rest using server\-side encryption with customer master keys \(CMKs\) stored in AWS KMS\. This section explains additional configuration that you add to direct Amazon S3 to replicate these objects\. 
 
 **Important**  
-Replication of encrypted data is a server\-side process that occurs entirely within Amazon S3\. Replication does not support client\-side encryption\. 
+Replication of encrypted data is a server\-side process that occurs entirely within Amazon S3\.
 
 For an example with step\-by\-step instructions, see [Replicating encrypted objects](replication-walkthrough-4.md)\. For information about creating a replication configuration, see [Replicating objects](replication.md)\. 
 


### PR DESCRIPTION
*Issue #, if available:*
Files encrypted using client-side encryption are replicated as fine. 

#### steps to reproduce:
1. create two buckets source and destination 
2. set up replication between the two buckets
3. upload a file that is encrypted using client-side encryption to the source S3 bucket and after a few moments the file will be replicated to the destination bucket.
I wrote a sample app for encrypting and decrypting a text file:
https://github.com/AureaMohammadAlavi/s3-client-side-encryption 
you can use this app or AWS sample apps to upload an encrypted file to the source S3 bucket.

*Description of changes:*
removed "Replication does not support client-side encryption."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
