### PR TITLE
Update Versioning.md

### DIFF
--- a/doc_source/Versioning.md
+++ b/doc_source/Versioning.md
@@ -24,7 +24,7 @@ Buckets can be in one of three states:
 
 You enable and suspend versioning at the bucket level\. After you version\-enable a bucket, it can never return to an unversioned state\. But you can *suspend* versioning on that bucket\.
 
-The versioning state applies to all \(never some\) of the objects in that bucket\. The first time you enable a bucket for versioning, objects in it are thereafter *always* versioned and given a unique version ID\. Note the following:
+The versioning state applies to all \(never some\) of the objects in that bucket\. When you enable versioning in a bucket, all new objects are versioned and given a unique version ID. Objects that already existed in the bucket at the time versioning was enabled will thereafter *always* be versioned and given a unique version ID when they are modified by future requests\. Note the following:
 + Objects that are stored in your bucket before you set the versioning state have a version ID of `null`\. When you enable versioning, existing objects in your bucket do not change\. What changes is how Amazon S3 handles the objects in future requests\. For more information, see [Working with objects in a versioning\-enabled bucket](manage-objects-versioned-bucket.md)\.
 + The bucket owner \(or any user with appropriate permissions\) can suspend versioning to stop accruing object versions\. When you suspend versioning, existing objects in your bucket do not change\. What changes is how Amazon S3 handles objects in future requests\. For more information, see [Working with objects in a versioning\-suspended bucket](VersionSuspendedBehavior.md)\.
 


### PR DESCRIPTION
On line #27 the sentences "The first time you enable a bucket for versioning, objects in it are thereafter always versioned and given a unique version ID" 
is not entirely accurate.  The phrase "first time" is not accurate because versioning could be enabled for a bucket, then suspended, and then enabled again. The rules described here would apply to the second time versioning is enabled in a bucket not just the first. Additionally, the existing objects are not immediately modified (given a version id) once versioning is enabled, there has to be a future request to the object in order for it to be modified.  
Thank you for taking the time to review my pull request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
