### PR TITLE
Update versioning-workflows.md

### DIFF
--- a/doc_source/versioning-workflows.md
+++ b/doc_source/versioning-workflows.md
@@ -6,7 +6,7 @@ Welcome to the new **Amazon S3 User Guide**\! The Amazon S3 User Guide combines 
 
 # How S3 Versioning works<a name="versioning-workflows"></a>
 
-You can use S3 Versioning to keep multiple versions of an object in one bucket and to give you the ability to restore objects that are accidentally deleted or overwritten\. For example, if you delete an object, instead of removing it permanently, Amazon S3 inserts a delete marker, which becomes the current object version\. You can then restore the previous version\. For more information, see [Deleting object versions from a versioning\-enabled bucket](DeletingObjectVersions.md)\. If you overwrite an object, it results in a new object version in the bucket\. You can always restore the previous version\.
+You can use S3 Versioning to keep multiple versions of an object in one bucket and enable you to restore objects that are accidentally deleted or overwritten\. For example, if you delete an object, instead of removing it permanently, Amazon S3 inserts a delete marker, which becomes the current object version\. You can then restore the previous version\. For more information, see [Deleting object versions from a versioning\-enabled bucket](DeletingObjectVersions.md)\. If you overwrite an object, it results in a new object version in the bucket\. You can always restore the previous version\.
 
 Each S3 bucket that you create has a *versioning* subresource associated with it\. \(For more information, see [Bucket configuration options](UsingBucket.md#bucket-config-options-intro)\.\) By default, your bucket is *unversioned*, and the versioning subresource stores the empty versioning configuration, as follows\.
 

--- a/doc_source/versioning-workflows.md
+++ b/doc_source/versioning-workflows.md
@@ -6,7 +6,7 @@ Welcome to the new **Amazon S3 User Guide**\! The Amazon S3 User Guide combines 
 
 # How S3 Versioning works<a name="versioning-workflows"></a>
 
-You can use S3 Versioning to keep multiple versions of an object in one bucket and prevent objects from being accidentally deleted or overwritten\. For example, if you delete an object, instead of removing it permanently, Amazon S3 inserts a delete marker, which becomes the current object version\. You can then restore the previous version\. For more information, see [Deleting object versions from a versioning\-enabled bucket](DeletingObjectVersions.md)\. If you overwrite an object, it results in a new object version in the bucket\. You can always restore the previous version\.
+You can use S3 Versioning to keep multiple versions of an object in one bucket and to give you the ability to restore objects that are accidentally deleted or overwritten\. For example, if you delete an object, instead of removing it permanently, Amazon S3 inserts a delete marker, which becomes the current object version\. You can then restore the previous version\. For more information, see [Deleting object versions from a versioning\-enabled bucket](DeletingObjectVersions.md)\. If you overwrite an object, it results in a new object version in the bucket\. You can always restore the previous version\.
 
 Each S3 bucket that you create has a *versioning* subresource associated with it\. \(For more information, see [Bucket configuration options](UsingBucket.md#bucket-config-options-intro)\.\) By default, your bucket is *unversioned*, and the versioning subresource stores the empty versioning configuration, as follows\.
 


### PR DESCRIPTION
I added a suggestion for line #9. Versioning doesn't actually prevent an object from being overwritten or deleted, it just gives you the ability to restore the object, if necessary, to a previous version. Your application will likely show the object as deleted or overwritten until the object is restored.  
 Actually preventing an object from being overwritten or deleted would involve using an Object Lock - https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html

Thank you for taking the time to review my pull request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
