### PR TITLE
S3 V2 Replication schema now supports delete markers

### DIFF
--- a/doc_source/replication-add-config.md
+++ b/doc_source/replication-add-config.md
@@ -45,7 +45,6 @@ The following sections provide additional information\.
 Each rule must include the rule's status and priority, and indicate whether to replicate delete markers\. 
 + `Status` indicates whether the rule is enabled or disabled\. If a rule is disabled, Amazon S3 doesn't perform the actions specified in the rule\. 
 + `Priority` indicates which rule has precedence whenever two or more replication rules conflict\. Amazon S3 will attempt to replicate objects according to all replication rules\. However, if there are two or more rules with the same destination bucket, then objects will be replicated according to the rule with the highest priority\. The higher the number, the higher the priority\.
-+ Currently, delete markers aren't replicated, so you must set `DeleteMarkerReplication` to `Disabled`\.
 
 In the destination configuration, you must provide the name of the bucket or buckets where you want Amazon S3 to replicate objects\. 
 
@@ -541,7 +540,7 @@ For backward compatibility, Amazon S3 continues to support the XML V1 replicatio
   ```
 
   For backward compatibility, `Amazon S3 ` continues to support the V1 configuration\. 
-+ When you delete an object from your source bucket without specifying an object version ID, Amazon S3 adds a delete marker\. If you use V1 of the replication configuration XML, Amazon S3 replicates delete markers that resulted from user actions\. In other words, if the user deleted the object, and not if Amazon S3 deleted it because the object expired as part of lifecycle action\. In V2, Amazon S3 doesn't replicate delete markers\. Therefore, you must set the `DeleteMarkerReplication` element to `Disabled`\. 
++ When you delete an object from your source bucket without specifying an object version ID, Amazon S3 adds a delete marker\. If you use V1 of the replication configuration XML, Amazon S3 replicates delete markers that resulted from user actions\. In other words, if the user deleted the object, and not if Amazon S3 deleted it because the object expired as part of lifecycle action\. In V2, delete markers are now replicated if enabled, however they do not replicate rules with tag filters\.
 
   ```
   ...
@@ -551,7 +550,10 @@ For backward compatibility, Amazon S3 continues to support the XML V1 replicatio
           <Priority>integer</Priority>
           <DeleteMarkerReplication>
              <Status>Disabled</Status>
-          </DeleteMarkerReplication>        
+          </DeleteMarkerReplication>
+          <Filter>
+             <Tag>Tax</Tag>
+          </Filter>        
           <Destination>        
              <Bucket>arn:aws:s3:::bucket-name</Bucket> 
           </Destination>    


### PR DESCRIPTION
S3 V2 replication schema now has support for delete markers. Suggesting a change to the documentation to make it more clear as it suggests that V2 does not replicate delete markers at all, however it is only rules with tag filters that must be disabled. https://aws.amazon.com/about-aws/whats-new/2020/11/amazon-s3-replication-adds-support-for-replicating-delete-markers/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
