### PR TITLE
Fix wrong client method for S3 object upload Presigned URL (Python example)

### DIFF
--- a/doc_source/PresignedUrlUploadObject.md
+++ b/doc_source/PresignedUrlUploadObject.md
@@ -184,7 +184,7 @@ Generate a presigned URL to share an object by using the SDK for Python \(Boto3\
 ```
 import boto3
     url = boto3.client('s3').generate_presigned_url(
-    ClientMethod='get_object', 
+    ClientMethod='put_object', 
     Params={'Bucket': 'BUCKET_NAME', 'Key': 'OBJECT_KEY'},
     ExpiresIn=3600)
 ```


### PR DESCRIPTION
*Issue #, if available:*

The example is mentioning put object but it is using `get_object` as client method.

*Description of changes:*

Update the client method as `put_object` so it actually to give pre-signed URL for `s3:PutObject` and allow upload object action.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
