### PR TITLE
Make it clear that expirations are not charged

### DIFF
--- a/doc_source/lifecycle-expire-general-considerations.md
+++ b/doc_source/lifecycle-expire-general-considerations.md
@@ -1,6 +1,6 @@
 # Expiring objects<a name="lifecycle-expire-general-considerations"></a>
 
- When an object reaches the end of its lifetime based on its lifecycle policy, Amazon S3 queues it for removal and removes it asynchronously\. There might be a delay between the expiration date and the date at which Amazon S3 removes an object\. You are not charged for storage time associated with an object that has expired\. 
+ When an object reaches the end of its lifetime based on its lifecycle policy, Amazon S3 queues it for removal and removes it asynchronously\. There might be a delay between the expiration date and the date at which Amazon S3 removes an object\. You are not charged for the expiration nor storage time associated with an object that has expired\. 
 
  To find when an object is scheduled to expire, use the [HEAD Object](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html) or the [GET Object](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html) API operations\. These API operations return response headers that provide this information\. 
 


### PR DESCRIPTION
*Description of changes:*

Lifecycle transitions are charged, but expirations are not. Since they are configured in the same place it's not easy to know that expirations are in fact free. The only charges are storage in some situations. This change makes it clear that the charges described further down are only about storage.

Apolgies that the last paragraph looks edited, it's just the GitHub editor that adds a newline and I don't see a way to not make it do that.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
