### PR TITLE
Fix JavaScript in PresignedUrlUploadObject Markdown

### DIFF
--- a/doc_source/PresignedUrlUploadObject.md
+++ b/doc_source/PresignedUrlUploadObject.md
@@ -222,7 +222,7 @@ const run = async () => {
       expiresIn: 3600,
     });
     console.log(
-      `\nPutting "${params.Key}" using signedUrl with body "${bucketParams.Body}" in v3`
+      `\nPutting "${bucketParams.Key}" using signedUrl with body "${bucketParams.Body}" in v3`
     );
     console.log(signedUrl);
     const response = await fetch(signedUrl);
@@ -237,7 +237,7 @@ const run = async () => {
     // Delete the object.
     console.log(`\nDeleting object "${bucketParams.Key}"} from bucket`);
     await s3Client.send(
-      new DeleteObjectCommand({ Bucket: bucketParams.Bucket, Key: params.Key })
+      new DeleteObjectCommand({ Bucket: bucketParams.Bucket, Key: bucketParams.Key })
     );
   } catch (err) {
     console.log("Error deleting object", err);

--- a/doc_source/PresignedUrlUploadObject.md
+++ b/doc_source/PresignedUrlUploadObject.md
@@ -225,7 +225,11 @@ const run = async () => {
       `\nPutting "${bucketParams.Key}" using signedUrl with body "${bucketParams.Body}" in v3`
     );
     console.log(signedUrl);
-    const response = await fetch(signedUrl);
+    const response = await fetch(signedUrl, {
+      method: "PUT",
+      body: bucketParams.body,
+      headers: {'Content-Type': bucketParams.ContentType}
+    });
     console.log(
       `\nResponse returned by signed URL: ${await response.text()}\n`
     );


### PR DESCRIPTION
Couple of commits to fix the Javascript example in PresignedUrlUploadObject.md which will allow the PUT request to add content to the S3 bucket.

- `params` doesn't exist, needs to be `bucketParams`
- The PUT request failed the signature compare. Needed more options passed to the **fetch** method
- Content-Type is required too