### PR TITLE
Add <!DOCTYPE html> to example index.html

### DIFF
--- a/doc_source/IndexDocumentSupport.md
+++ b/doc_source/IndexDocumentSupport.md
@@ -45,6 +45,7 @@ When you enable static website hosting for your bucket, you enter the name of th
    If you don't have an `index.html` file, you can use the following HTML to create one:
 
    ```
+   <!DOCTYPE html>
    <html xmlns="http://www.w3.org/1999/xhtml" >
    <head>
        <title>My Website Home Page</title>


### PR DESCRIPTION
Chrome 92.0.4515.107 was downloading the document instead of rendering it as a web page even when Content-Type on the S3 object was configured to "text/html" and S3 bucket configured to for hosting a static website.   Adding the <!DOCYTYPE html> line caused the browser to become happy to render it.

Proposing this change in example documentation to help someone else avoid this confusion.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
