### PR TITLE
S3 Inventory Athena doc sample query fix

### DIFF
--- a/doc_source/storage-inventory-athena-query.md
+++ b/doc_source/storage-inventory-athena-query.md
@@ -18,7 +18,7 @@ Athena can query Amazon S3 inventory files in ORC, Parquet, or CSV format\. When
             is_latest boolean,
             is_delete_marker boolean,
             size bigint,
-            last_modified_date bigint,
+            last_modified_date timestamp,
             e_tag string,
             storage_class string,
             is_multipart_uploaded boolean,


### PR DESCRIPTION
The sample Athena query for ORC-formatted inventory uses `bigint` instead of `timestamp` for the `last_modified_date` data type. This results in an error when attempting to query the table:

> HIVE_CURSOR_ERROR: Failed to read ORC file: s3://….orc
> This query ran against the "…" database, unless qualified by the query. Please post the error message on our forum or contact customer support with Query Id: …

This PR corrects the type to `timestamp` which matches the ORC schema.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
