### PR TITLE
Add python example to s3 replication walkthrough

### DIFF
--- a/doc_source/replication-walkthrough1.md
+++ b/doc_source/replication-walkthrough1.md
@@ -478,6 +478,7 @@ PROFILE = '*** profile name ***'
 SOURCE_BUCKET = '*** source bucket ***'
 DESTINATION_BUCKET = '*** destination bucket ***'
 PREFIX = '*** folder/file prefix ***'
+ROLE_NAME = '*** role name ***'
 
 SESSION = boto3.Session(profile_name=PROFILE)
 S3_client = SESSION.client('s3')
@@ -570,10 +571,8 @@ def main():
         VersioningConfiguration={'Status': 'Enabled'}
     )
 
-    role_name = f'replicationRole-{SOURCE_BUCKET}-{DESTINATION_BUCKET}'
-    policy_name = f'replicationPolicy-{SOURCE_BUCKET}-{DESTINATION_BUCKET}'
     try:
-        res = IAM_CLIENT.get_role(RoleName=role_name)
+        res = IAM_CLIENT.get_role(RoleName=ROLE_NAME)
         role_exists = True
         role_arn = res['Role']['Arn']
     except IAM_CLIENT.exceptions.NoSuchEntityException:
@@ -582,12 +581,13 @@ def main():
 
     if not role_exists:
         print('Role for replication doesn\'t exists, creating it...')
-        res = IAM_CLIENT.create_role(RoleName=role_name, AssumeRolePolicyDocument=get_iam_role())
+        res = IAM_CLIENT.create_role(RoleName=ROLE_NAME, AssumeRolePolicyDocument=get_iam_role())
         role_arn = res['Role']['Arn']
 
         print('Attaching policy...')
+        policy_name = f'{ROLE_NAME}-replicationPolicy'
         IAM_CLIENT.put_role_policy(
-            RoleName=role_name,
+            RoleName=ROLE_NAME,
             PolicyName=policy_name,
             PolicyDocument=get_role_policy()
         )

--- a/doc_source/replication-walkthrough1.md
+++ b/doc_source/replication-walkthrough1.md
@@ -570,8 +570,8 @@ def main():
         VersioningConfiguration={'Status': 'Enabled'}
     )
 
-    role_name = f'replicationRole-{PROFILE}'
-    policy_name = f'replicationPolicy-{PROFILE}'
+    role_name = f'replicationRole-{SOURCE_BUCKET}-{DESTINATION_BUCKET}'
+    policy_name = f'replicationPolicy-{SOURCE_BUCKET}-{DESTINATION_BUCKET}'
     try:
         res = IAM_CLIENT.get_role(RoleName=role_name)
         role_exists = True


### PR DESCRIPTION
Update the replication-walkthrough1.md to include a Python 3 SDK (Boto) example

*Issue #, if available:*

*Description of changes:*
Update the replication-walkthrough1.md to include a Python 3 SDK (Boto) example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
