### PR TITLE
s3:ListAllMyBuckets takes only "*" as resource reference

### DIFF
--- a/doc_source/using-with-s3-actions.md
+++ b/doc_source/using-with-s3-actions.md
@@ -58,7 +58,7 @@ The following example user policy grants the `s3:CreateBucket`, `s3:ListAllMyBuc
             "s3:GetBucketLocation"  
          ],
          "Resource":[
-            "arn:aws:s3:::*"
+            "*"
          ]
        }
     ]


### PR DESCRIPTION
When trying to follow the documentation to specify `arn:aws:s3:::*` as the resource for `s3:ListAllMyBucket`, the permission was ignored by the API.

The change is to update the document to the broader `*` resource specification.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
