### PR TITLE
Changed file/parts size limits units from *B to *iB on "Amazon S3 multipart upload limits" page

### DIFF
--- a/doc_source/qfacts.md
+++ b/doc_source/qfacts.md
@@ -5,9 +5,9 @@ The following table provides multipart upload core specifications\. For more inf
 
 | Item | Specification | 
 | --- | --- | 
-| Maximum object size | 5 TB  | 
+| Maximum object size | 5 TiB  | 
 | Maximum number of parts per upload | 10,000 | 
 | Part numbers | 1 to 10,000 \(inclusive\) | 
-| Part size | 5 MB to 5 GB\. There is no minimum size limit on the last part of your multipart upload\. | 
+| Part size | 5 MiB to 5 GiB\. There is no minimum size limit on the last part of your multipart upload\. | 
 | Maximum number of parts returned for a list parts request | 1000  | 
 | Maximum number of multipart uploads returned in a list multipart uploads request | 1000  | 


### PR DESCRIPTION
The usage of *B caused some repeating confusion, for example https://stackoverflow.com/questions/70131487

*Description of changes:*

- Changed file/parts size limits units from *B to *iB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
