### PR TITLE
Modify example to limit principals to specific role

### DIFF
--- a/doc_source/amazon-s3-policy-keys.md
+++ b/doc_source/amazon-s3-policy-keys.md
@@ -316,7 +316,9 @@ This example bucket policy *allows* PutObject requests by clients that have a TL
     "Statement": [
         {
             "Effect": "Allow",
-            "Principal": "*",
+            "Principal": {
+                "AWS": "arn:aws:iam::AWS-ACCOUNT-ID:role/ROLE-NAME"
+            },
             "Action": "s3:PutObject",
             "Resource": [
                 "arn:aws:s3:::DOC-EXAMPLE-BUCKET1",


### PR DESCRIPTION

*Fixes Issue:* #60

*Description of changes:*
Modify example to limit principals to specific role instead of anonymous users. Therefore users can not simply copy and paste that example and grant the whole world write access to their bucket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
