### PR TITLE
Security: Correct querying anonymous requester events example

### DIFF
--- a/doc_source/cloudtrail-request-identification.md
+++ b/doc_source/cloudtrail-request-identification.md
@@ -278,7 +278,7 @@ WHERE
   AND eventTime BETWEEN '2019-07-05T00:00:00Z' and '2019-07-06T00:00:00Z'
 ```
 
-**Example — Select all anonymous requester events to a bucket in a certain period and print only EventTime, EventSource, SourceIP, UserAgent, BucketName, UserIdentity, and UserARN**  
+**Example — Select all anonymous requester events to a bucket in a certain period and print only EventTime, EventName, EventSource, SourceIP, UserAgent, BucketName, UserARN, and AccountID**  
 
 ```
 SELECT
@@ -289,11 +289,11 @@ SELECT
   userAgent, 
   json_extract_scalar(requestParameters, '$.bucketName') as bucketName, 
   userIdentity.arn as userArn,
-  userIdentity.principalId 
+  userIdentity.accountId 
 FROM
   s3_cloudtrail_events_db.cloudtrail_myawsexamplebucket_table
 WHERE
-  userIdentity.principalId='ANONYMOUS_PRINCIPAL'
+  userIdentity.accountId='ANONYMOUS_PRINCIPAL'
   AND eventTime BETWEEN '2019-07-05T00:00:00Z' and '2019-07-06T00:00:00Z'
 ```
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When an anonymous user makes a request to an S3 bucket, it appears that the `ANONYMOUS_PRINCIPAL` value is in the `userIdentity.accountId` field, not the `userIdentity.principalId` field which the example shows.

This example could misguide users into thinking that they had no unauthenticated requests to their buckets and data, whereas it was just because the query was incorrect.

I couldn't find any CloudTrail docs which explain this, but I can include 2 examples from the real world via an Athena query:


![Screenshot 2022-06-30 at 17 31 29](https://user-images.githubusercontent.com/8210662/176730582-b5b47f2d-4e43-44c1-986a-9363ceb3f94b.png)
![Screenshot 2022-06-30 at 17 31 57](https://user-images.githubusercontent.com/8210662/176730592-256ae2d3-2cbc-4229-8de7-88aefeca55f4.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
