### PR TITLE
Include detail on setting service-role as the path for S3 cross-region replication documentation 

### DIFF
--- a/doc_source/setting-repl-config-perm-overview.md
+++ b/doc_source/setting-repl-config-perm-overview.md
@@ -98,6 +98,8 @@ The permissions described here are related to the minimum replication configurat
 
 When the source and destination buckets aren't owned by the same accounts, the owner of the destination bucket must also add a bucket policy to grant the owner of the source bucket permissions to perform replication actions, as follows\. In this policy, `DOC-EXAMPLE-BUCKET2` is the destination bucket\.
 
+If creating the role manually and not auto-generating, ensure that you set the role path as `/service-role/` so that it can be used as per the below policy. For more information, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html)
+
 ```
 {
    "Version":"2012-10-17",

--- a/doc_source/setting-repl-config-perm-overview.md
+++ b/doc_source/setting-repl-config-perm-overview.md
@@ -98,7 +98,7 @@ The permissions described here are related to the minimum replication configurat
 
 When the source and destination buckets aren't owned by the same accounts, the owner of the destination bucket must also add a bucket policy to grant the owner of the source bucket permissions to perform replication actions, as follows\. In this policy, `DOC-EXAMPLE-BUCKET2` is the destination bucket\.
 
-If creating the role manually and not auto-generating, ensure that you set the role path as `/service-role/` so that it can be used as per the below policy. For more information, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html)
+If creating the role manually and not auto-generating, ensure that you set the role path as `/service-role/` so that it can be used as per the below policy. For more information, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html) in the *IAM User Guide*\.
 
 ```
 {


### PR DESCRIPTION
There is no mention prior to the bucket policy that if cross-account, the IAM role path MUST be /service-role/. If allowing CRR to automatically generate a role it creates this as so, but if you generate manually through console,CLI or Terraform with the correct permissions it will not work unless /service-role/ is the identifier.

*Issue #, if available:*

*Description of changes:*
Add sentence about setting /service-role/ path. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
