### PR TITLE
Update managed policies for IAM User

### DIFF
--- a/doc_source/tutorial-s3-object-lambda-uppercase.md
+++ b/doc_source/tutorial-s3-object-lambda-uppercase.md
@@ -38,6 +38,7 @@ Your IAM user requires the following policies:
 + [AWSLambda\_FullAccess](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/AWSLambda_FullAccess$jsonEditor) – Grants permissions to all Lambda actions\. 
 + [IAMFullAccess](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/IAMFullAccess$jsonEditor) – Grants permissions to all IAM actions\. 
 + [IAMAccessAnalyzerReadOnlyAccess](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/IAMAccessAnalyzerReadOnlyAccess$jsonEditor) – Grants permissions to read all access information provided by IAM Access Analyzer\. 
++ [CloudWatchLogsFullAccess](https://console.aws.amazon.com/iam/home?#/policies/arn:aws:iam::aws:policy/CloudWatchLogsFullAccess$serviceLevelSummary) – Provides full access to CloudWatch Logs\.
 
 **Note**  
 For simplicity, this tutorial uses full\-access AWS managed policies\. For production use, we recommend that you instead grant only the minimum permissions necessary for your use case, in accordance with [security best practices](security-best-practices.md#security-best-practices-prevent)\.  


### PR DESCRIPTION
*Issue #, if available:*

When doing clean up of Logs in CloudWatch, one would get a unauthorized message. This was because the user did not have access to `CloudWatchLogsFullAccess` 

*Description of changes:*

Updated the document to enable the access to  `CloudWatchLogsFullAccess` policy. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
