### PR TITLE
Updating Go URL presigning with expiration values

### DIFF
--- a/doc_source/PresignedUrlUploadObject.md
+++ b/doc_source/PresignedUrlUploadObject.md
@@ -47,10 +47,17 @@ The following code examples show how to create a presigned URL for S3 and upload
 	fmt.Println("Create Presign client")
 	presignClient := s3.NewPresignClient(&client)
 
-	presignResult, err := presignClient.PresignGetObject(context.TODO(), &s3.GetObjectInput{
+	presignParams := &s3.GetObjectInput{
 		Bucket: aws.String(name),
 		Key:    aws.String("path/myfile.jpg"),
-	})
+	}
+
+	// Apply an expiration via an option function
+	presignDuration := func(po *s3.PresignOptions) {
+		po.Expires = 5 * time.Minute
+	}
+
+	presignResult, err := presignClient.PresignGetObject(context.TODO(), presignParams, presignDuration)
 
 	if err != nil {
 		panic("Couldn't get presigned URL for GetObject")

--- a/doc_source/example_s3_Scenario_PresignedUrl_section.md
+++ b/doc_source/example_s3_Scenario_PresignedUrl_section.md
@@ -19,10 +19,17 @@ The source code for these examples is in the [AWS Code Examples GitHub repositor
 	fmt.Println("Create Presign client")
 	presignClient := s3.NewPresignClient(&client)
 
-	presignResult, err := presignClient.PresignGetObject(context.TODO(), &s3.GetObjectInput{
+	presignParams := &s3.GetObjectInput{
 		Bucket: aws.String(name),
 		Key:    aws.String("path/myfile.jpg"),
-	})
+	}
+
+	// Apply an expiration via an option function
+	presignDuration := func(po *s3.PresignOptions) {
+		po.Expires = 5 * time.Minute
+	}
+
+	presignResult, err := presignClient.PresignGetObject(context.TODO(), presignParams, presignDuration)
 
 	if err != nil {
 		panic("Couldn't get presigned URL for GetObject")


### PR DESCRIPTION
The Go examples for presigning URLs are missing an explanation for how to set the expiration value. This provides an example for setting the expiration to 5 minutes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
