### PR TITLE
Changing the "Grant anonymous permissions" section

### DIFF
--- a/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
+++ b/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
@@ -52,6 +52,8 @@ For detailed examples that provide step\-by\-step instructions, see [Example 1: 
 
 To grant permission to everyone, also referred as anonymous access, you set the wildcard \(`"*"`\) as the `Principal` value\. For example, if you configure your bucket as a website, you want all the objects in the bucket to be publicly accessible\.
 
+For anonymous users, the following elements are equivalent:
+
 ```
 "Principal":"*"
 ```
@@ -60,9 +62,7 @@ To grant permission to everyone, also referred as anonymous access, you set the 
 "Principal":{"AWS":"*"}
 ```
 
-Using `"Principal": "*"` with an `Allow` effect in a resource\-based policy allows anyone, even if they’re not signed in to AWS, to access your resource\. 
-
-Using `"Principal" : { "AWS" : "*" }` with an `Allow` effect in a resource\-based policy allows any root user, IAM user, assumed\-role session, or federated user in any account in the same partition to access your resource\. For more information, see [All principals](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-anonymous) in the *IAM User Guide*\.
+For more information, see [All principals](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-anonymous) in the *IAM User Guide*\.
 
 You cannot use a wildcard to match part of a principal name or ARN\.
 

--- a/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
+++ b/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
@@ -52,8 +52,6 @@ For detailed examples that provide step\-by\-step instructions, see [Example 1: 
 
 To grant permission to everyone, also referred as anonymous access, you set the wildcard \(`"*"`\) as the `Principal` value\. For example, if you configure your bucket as a website, you want all the objects in the bucket to be publicly accessible\.
 
-For anonymous users, the following elements are equivalent:
-
 ```
 "Principal":"*"
 ```

--- a/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
+++ b/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
@@ -66,9 +66,6 @@ For more information, see [All principals](https://docs.aws.amazon.com/IAM/lates
 
 You cannot use a wildcard to match part of a principal name or ARN\.
 
-**Important**  
-Because anyone can create an AWS account, the **security level** of these two methods is equivalent, even though they function differently\.
-
 **Warning**  
 Use caution when granting anonymous access to your Amazon S3 bucket\. When you grant anonymous access, anyone in the world can access your bucket\. We highly recommend that you never grant any kind of anonymous write access to your S3 bucket\.
 

--- a/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
+++ b/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
@@ -62,9 +62,16 @@ For anonymous users, the following elements are equivalent:
 "Principal":{"AWS":"*"}
 ```
 
-For more information, see [All principals](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-anonymous) in the *IAM User Guide*\.
+Using `"Principal": "*"` with an `Allow` effect in a resource\-based policy allows anyone, even if they’re not signed in to AWS, to access your resource\. 
+
+Using `"Principal" : { "AWS" : "*" }` with an `Allow` effect in a resource\-based policy allows any root user, IAM user, assumed\-role session, or federated user in any account in the same partition to access your resource\. 
+
+For anonymous users, these two methods are equivalent. For more information, see [All principals](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-anonymous) in the *IAM User Guide*\.
 
 You cannot use a wildcard to match part of a principal name or ARN\.
+
+**Important**  
+Because anyone can create an AWS account, the **security level** of these two methods is equivalent, even though they function differently\.
 
 **Warning**  
 Use caution when granting anonymous access to your Amazon S3 bucket\. When you grant anonymous access, anyone in the world can access your bucket\. We highly recommend that you never grant any kind of anonymous write access to your S3 bucket\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changing the "Grant anonymous permissions" section because "Principal":"*" and "Principal":{"AWS":"*"} are equivalent, as explained at https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-anonymous


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
