### PR TITLE
fix a typo in url

### DIFF
--- a/doc_source/access-bucket-intro.md
+++ b/doc_source/access-bucket-intro.md
@@ -57,7 +57,7 @@ In addition to accessing a bucket directly, you can access a bucket through an a
 S3 access points only support virtual\-host\-style addressing\. To address a bucket through an access point, use the following format\.
 
 ```
-https://AccessPointName-AccountId.s3-accesspoint.region.amazonaws.com.
+https://AccessPointName-AccountId.s3-accesspoint.region.amazonaws.com
 ```
 
 **Note**  


### PR DESCRIPTION
remove an unnecessary dot at the end of the url `https://AccessPointName-AccountId.s3-accesspoint.region.amazonaws.com`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
