### PR TITLE
Update example_s3_Scenario_PresignedUrl_section.md

### DIFF
--- a/doc_source/example_s3_Scenario_PresignedUrl_section.md
+++ b/doc_source/example_s3_Scenario_PresignedUrl_section.md
@@ -406,7 +406,7 @@ require "net/http"
 # @return [URI, nil] The parsed URI if successful; otherwise nil.
 def get_presigned_url(bucket, object_key)
   url = bucket.object(object_key).presigned_url(:put)
-  puts "Created presigned URL: #{url}."
+  puts "Created presigned URL: #{url}"
   URI(url)
 rescue Aws::Errors::ServiceError => e
   puts "Couldn't create presigned URL for #{bucket.name}:#{object_key}. Here's why: #{e.message}"


### PR DESCRIPTION
Remove trailing period from the pre-signed URL (it's easy to copy it by mistake resulting in invalid URL)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
