### PR TITLE
Adding permissions to change object ownership on destination objects

### DIFF
--- a/doc_source/setting-repl-config-perm-overview.md
+++ b/doc_source/setting-repl-config-perm-overview.md
@@ -88,7 +88,8 @@ This section explains the trust policy and minimum required permissions policy\.
            "Action":[
               "s3:ReplicateObject",
               "s3:ReplicateDelete",
-              "s3:ReplicateTags"
+              "s3:ReplicateTags",
+              "s3:s3:ObjectOwnerOverrideToBucketOwner"
            ],
            "Resource":"arn:aws:s3:::DOC-EXAMPLE-BUCKET2/*"
         }
@@ -133,7 +134,8 @@ The ARN format of the role may appear different\. If the role was created using 
          },
          "Action":[
             "s3:ReplicateDelete",
-            "s3:ReplicateObject"
+            "s3:ReplicateObject",
+            "s3:ObjectOwnerOverrideToBucketOwner"
          ],
          "Resource":"arn:aws:s3:::DOC-EXAMPLE-BUCKET2/*"
       },


### PR DESCRIPTION
Without this when users select the "change object ownership" option on the replication job it fails. Very difficult to troubleshoot!

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
