### PR TITLE
Remove closing curly brace from comment in JS example

### DIFF
--- a/doc_source/example_s3_GetObject_section.md
+++ b/doc_source/example_s3_GetObject_section.md
@@ -295,7 +295,7 @@ export const bucketParams = {
 
 export const run = async () => {
   try {
-    // Get the object} from the Amazon S3 bucket. It is returned as a ReadableStream.
+    // Get the object from the Amazon S3 bucket. It is returned as a ReadableStream.
     const data = await s3Client.send(new GetObjectCommand(bucketParams));
     // Convert the ReadableStream to a string.
     return await data.Body.transformToString();


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Tiny change, fixes typo by removing closing curly brace from comment in GetObjectCommand JavaScript example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
