### PR TITLE
Update storage-inventory-athena-query.md

### DIFF
--- a/doc_source/storage-inventory-athena-query.md
+++ b/doc_source/storage-inventory-athena-query.md
@@ -43,7 +43,7 @@ Athena can query Amazon S3 Inventory files in ORC, Parquet, or CSV format\. When
        "projection.dt.format" = "yyyy-MM-dd-HH-mm",
        "projection.dt.range" = "2022-01-01-00-00,NOW",
        "projection.dt.interval" = "1",
-       "projection.dt.interval.unit" = "DAYS"
+       "projection.dt.interval.unit" = "HOURS"
      );
    ```
 

--- a/doc_source/storage-inventory-athena-query.md
+++ b/doc_source/storage-inventory-athena-query.md
@@ -88,7 +88,7 @@ Athena can query Amazon S3 Inventory files in ORC, Parquet, or CSV format\. When
        "projection.dt.format" = "yyyy-MM-dd-HH-mm",
        "projection.dt.range" = "2022-01-01-00-00,NOW",
        "projection.dt.interval" = "1",
-       "projection.dt.interval.unit" = "DAYS"
+       "projection.dt.interval.unit" = "HOURS"
      );
    ```
 


### PR DESCRIPTION
Recently we encountered an issue when creating a table in athena to query S3 inventory data where the partition `dt` changed from "2023-01-03-00-00" to "2023-01-04-01-00" which caused the projection to stop working. Therefore I believe the documentation should recommend setting an hourly interval

From the ticket we opened to AWS support: 

>> Here the table has partition projection properties configured with projection.dt.range as "2023-01-01-00-00,NOW" and projection interval set to 1 day. Therefore partition values calculated are like 2023-01-01-00-00, 2023-01-02-00-00, 2023-01-03-00-00, 2023-01-04-00-00, 2023-01-05-00-00, 2023-01-06-00-00 and so on. It looks for partitions of this format only. However, starting 5th of Jan partition values changed to '2023-01-05-01-00' which doesn't match partition values calculated by Athena.

>> In order to address this, we can change the projection interval to 1 hour. By doing this, Athena looks for partitions with 1 hour interval. Suppose projection.dt.range is "2023-01-01-00-00,NOW", it will look for 2023-01-01-00-00, 2023-01-01-01-00, ....... 2023-01-01-23-00, 2023-01-02-00-00, 2023-01-02-01-00, ............ 2023-01-02-23-00. This will address the change in s3 inventory directory partition values. Please change the following parameters for this - 
 'projection.dt.range'='2023-01-01-00-00,NOW',
 'projection.dt.interval'='1', 
 'projection.dt.interval.unit'='HOURS'
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
