### PR TITLE
Fix CVS typo

### DIFF
--- a/doc_source/s3-batch-replication-batch.md
+++ b/doc_source/s3-batch-replication-batch.md
@@ -51,6 +51,6 @@ If you do not filter based on replication status Batch Operations will attempt t
 
 ## Batch Replication completion report<a name="batch-replication-completion-report"></a>
 
-When you create a Batch Replication job, you can request a CVS completion report\. This report shows objects, replication success or failure codes, outputs, and descriptions\. For more information about job tracking and completion reports see, [Completion reports](batch-ops-job-status.md#batch-ops-completion-report)\. 
+When you create a Batch Replication job, you can request a CSV completion report\. This report shows objects, replication success or failure codes, outputs, and descriptions\. For more information about job tracking and completion reports see, [Completion reports](batch-ops-job-status.md#batch-ops-completion-report)\. 
 
 For a list of Replication failure codes and descriptions see, [Amazon S3 replication failure reasons](replication-failure-codes.md)\.


### PR DESCRIPTION
The completion report is a CSV, "Comma Separated Values", not CVS.

*Issue #, if available:* None

*Description of changes:* Change "CVS" typo to "CSV"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
