### PR TITLE
Fix link in batch operations guide

### DIFF
--- a/doc_source/specify-batchjob-manifest-xaccount-inventory.md
+++ b/doc_source/specify-batchjob-manifest-xaccount-inventory.md
@@ -116,4 +116,4 @@ The following console procedure contains the high\-level steps for setting up pe
 
    For general information about creating a job, see [Creating an S3 Batch Operations job](batch-ops-create-job.md)\.
 
-   For information about creating a job using the console, see [Creating an S3 Batch Operations job](batch-ops-create-job.md)\.
+   For information about creating a job using the console, see [Creating an S3 Batch Operations job using the s3 console](batch-ops-create-job.md#using-the-s3-console)\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Links should point to a specific section instead of both the links leading to the same page, at the start. Helps the readers avoid a bit of scrolling and confusion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
