### PR TITLE
Fix Athena query in S3 access logs usage

### DIFF
--- a/doc_source/using-s3-access-logs-to-identify-requests.md
+++ b/doc_source/using-s3-access-logs-to-identify-requests.md
@@ -145,7 +145,7 @@ The following Amazon Athena query example shows how to get all `PUT` object requ
 
 ```
 SELECT bucket_name, requester, remoteip, key, httpstatus, errorcode, requestdatetime
-FROM s3_access_logs_db
+FROM s3_access_logs_db.mybucket_logs
 WHERE operation='REST.PUT.OBJECT' AND
 parse_datetime(requestdatetime,'dd/MMM/yyyy:HH:mm:ss Z') 
 BETWEEN parse_datetime('2019-07-01:00:42:42','yyyy-MM-dd:HH:mm:ss')
@@ -159,7 +159,7 @@ The following Amazon Athena query example shows how to get all `GET` object requ
 
 ```
 SELECT bucket_name, requester, remoteip, key, httpstatus, errorcode, requestdatetime
-FROM s3_access_logs_db
+FROM s3_access_logs_db.mybucket_logs
 WHERE operation='REST.GET.OBJECT' AND
 parse_datetime(requestdatetime,'dd/MMM/yyyy:HH:mm:ss Z') 
 BETWEEN parse_datetime('2019-07-01:00:42:42','yyyy-MM-dd:HH:mm:ss')
@@ -187,7 +187,7 @@ The following Amazon Athena query shows how to identify all requests to your S3 
 
 ```
 SELECT bucket_name, requester, key, operation, aclrequired, requestdatetime
-FROM s3_access_logs_db
+FROM s3_access_logs_db.mybucket_logs
 WHERE aclrequired = 'Yes' AND
 parse_datetime(requestdatetime,'dd/MMM/yyyy:HH:mm:ss Z')
 BETWEEN parse_datetime('2022-05-10:00:00:00','yyyy-MM-dd:HH:mm:ss')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Athena query needs the _table_ name or _database.table_ name in _from_, without it, the query will fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
