### PR TITLE
Fix replicating encrypted objects

### DIFF
--- a/doc_source/replication-walkthrough-4.md
+++ b/doc_source/replication-walkthrough-4.md
@@ -267,4 +267,4 @@ In the replication configuration you specify the IAM role that Amazon S3 can ass
 
  For a code example to add replication configuration, see [Using the AWS SDKs](replication-walkthrough1.md#replication-ex1-sdk)\. You need to modify the replication configuration appropriately\. 
 
-For conceptual information, see [Replicating objects created with server\-side encryption \(SSE\-C, SSE\-S3, SSE\-KMS\)](replication-config-for-kms-objects.md)\. 
+For conceptual information, see [Replicating objects created with server\-side encryption \(SSE\-C, SSE\-S3, SSE\-KMS\)](replication-config-for-kms-objects.md)\.

--- a/doc_source/replication-walkthrough-4.md
+++ b/doc_source/replication-walkthrough-4.md
@@ -139,7 +139,7 @@ In the permissions policy, you specify the AWS KMS key IDs that will be used for
                      "StringLike":{
                         "kms:ViaService":"s3.us-east-1.amazonaws.com",
                         "kms:EncryptionContext:aws:s3:arn":[
-                           "arn:aws:s3:::source/*"
+                           "arn:aws:s3:::source"
                         ]
                      }
                   },
@@ -156,7 +156,7 @@ In the permissions policy, you specify the AWS KMS key IDs that will be used for
                      "StringLike":{
                         "kms:ViaService":"s3.us-west-2.amazonaws.com",
                         "kms:EncryptionContext:aws:s3:arn":[
-                           "arn:aws:s3:::destination/*"
+                           "arn:aws:s3:::destination"
                         ]
                      }
                   },

--- a/doc_source/replication-walkthrough-4.md
+++ b/doc_source/replication-walkthrough-4.md
@@ -267,4 +267,4 @@ In the replication configuration you specify the IAM role that Amazon S3 can ass
 
  For a code example to add replication configuration, see [Using the AWS SDKs](replication-walkthrough1.md#replication-ex1-sdk)\. You need to modify the replication configuration appropriately\. 
 
-For conceptual information, see [Replicating objects created with server\-side encryption \(SSE\-C, SSE\-S3, SSE\-KMS\)](replication-config-for-kms-objects.md)\.
+For conceptual information, see [Replicating objects created with server\-side encryption \(SSE\-C, SSE\-S3, SSE\-KMS\)](replication-config-for-kms-objects.md)\. 


### PR DESCRIPTION
*Issue #, if available:*
This code example states to use '/*' in the arn of "kms:EncryptionContext:aws:s3:arn" condition check. I deployed this example and found out that this setup is not working. The correct config is without '/*' at the end of bucket arn. 

*Description of changes:*
Removed incorrect suffix in the condition check for "kms:EncryptionContext:aws:s3:arn"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
